### PR TITLE
Use caller's scope for evaluating by default

### DIFF
--- a/lib/deterministic/either/match.rb
+++ b/lib/deterministic/either/match.rb
@@ -1,6 +1,7 @@
 module Deterministic::PatternMatching
 
-  def match(context=self, &block)
+  def match(context=nil, &block)
+    context ||= block.binding.eval('self')
     match = Match.new(self, context)
     match.instance_eval &block
     match.result

--- a/spec/lib/deterministic/either/match_spec.rb
+++ b/spec/lib/deterministic/either/match_spec.rb
@@ -82,6 +82,17 @@ describe Deterministic::Either::Match do
     }.to raise_error Deterministic::PatternMatching::NoMatchError
   end
 
+  it "can use methods from the caller's binding scope by default" do
+    def my_method
+      "it works"
+    end
+    expect(
+      Success(1).match do
+        success { my_method }
+      end
+    ).to eq "it works"
+  end
+
   it "allows for Either values to play with pattern matching comparisons" do
     class MyErrorHash < Hash
       def ==(error_type_symbol)


### PR DESCRIPTION
This allows the use of methods inside the same scope that the block given to `match` was created. It also avoids a lot of confusion when trying to use those methods doesn't work.

[Check out the spec](https://github.com/mindeavor/deterministic/blob/e431458c1c2ff3957f371d9f04efc0b401655b5d/spec/lib/deterministic/either/match_spec.rb#L85) for an example of what I'm talking about. Notice how you don't have to call `match(self) do`... you just call `match do` instead
