### PR TITLE
Specs: Don't include Deterministic in global scope. Fixes #12

### DIFF
--- a/lib/deterministic/core_ext/result.rb
+++ b/lib/deterministic/core_ext/result.rb
@@ -1,5 +1,3 @@
-include Deterministic
-
 module Deterministic
   module CoreExt
     module Result

--- a/lib/deterministic/result.rb
+++ b/lib/deterministic/result.rb
@@ -93,7 +93,7 @@ module Deterministic
     def try(proc=nil, &block)
       map(proc, &block)
     rescue => err
-      Failure(err)
+      Result::Failure.new(err)
     end
 
     alias :>= :try

--- a/spec/lib/deterministic/class_mixin_spec.rb
+++ b/spec/lib/deterministic/class_mixin_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe 'Class Mixin' do
+
+  describe 'try' do
+    module MyApp
+      class Thing
+        include Deterministic
+
+        def run
+          Success(11) >= method(:double)
+        end
+
+        def double(num)
+          Success(num * 2)
+        end
+      end
+    end
+
+    it "cleanly mixes into a class" do
+      result = MyApp::Thing.new.run
+      expect(result).to eq Deterministic::Success.new(22)
+    end
+  end
+end

--- a/spec/lib/deterministic/either_spec.rb
+++ b/spec/lib/deterministic/either_spec.rb
@@ -1,8 +1,9 @@
 require 'spec_helper'
 
-include Deterministic
-
 describe Deterministic::Either do
+  include Deterministic
+  Either = Deterministic::Either
+
   it "+ does not change operands" do
     l = Left(1)
     r = Right(2)

--- a/spec/lib/deterministic/option_spec.rb
+++ b/spec/lib/deterministic/option_spec.rb
@@ -1,9 +1,12 @@
 require 'spec_helper'
 require_relative 'monad_axioms'
 
-include Deterministic
 
 describe Deterministic::Option do
+  include Deterministic
+  Some = Deterministic::Some
+  None = Deterministic::None
+
   # nil?
   specify { expect(described_class.some?(nil)).to eq None }
   specify { expect(described_class.some?(1)).to be_some }
@@ -23,6 +26,9 @@ describe Deterministic::Option do
 end
 
 describe Deterministic::Option do
+  include Deterministic
+  Option = Deterministic::Option
+
   #  it_behaves_like 'a Monad' do
   #   let(:monad) { described_class }
   # end
@@ -109,13 +115,17 @@ describe Deterministic::Option do
 end
 
 describe Deterministic::Option::Some do
-   it_behaves_like 'a Monad' do
+  include Deterministic
+
+  it_behaves_like 'a Monad' do
     let(:monad) { described_class }
   end
 end
 
 describe Deterministic::Option::None do
-   it_behaves_like 'a Monad' do
+  include Deterministic
+
+  it_behaves_like 'a Monad' do
     let(:monad) { described_class }
   end
 end

--- a/spec/lib/deterministic/result/failure_spec.rb
+++ b/spec/lib/deterministic/result/failure_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper'
 require_relative '../monad_axioms'
 require_relative 'result_shared'
 
-include Deterministic
 
 describe Deterministic::Result::Failure do
+  include Deterministic
 
   it_behaves_like 'a Monad' do
     let(:monad) { described_class }
@@ -40,6 +40,8 @@ end
 
 
 describe "Chaining" do
+  include Deterministic
+
   it "#or" do
     expect(Success(1).or(Failure(2))).to eq Success(1)
     expect(Failure(1).or(Success(2))).to eq Success(2)

--- a/spec/lib/deterministic/result/match_spec.rb
+++ b/spec/lib/deterministic/result/match_spec.rb
@@ -1,8 +1,9 @@
 require 'spec_helper'
 
-include Deterministic
 
 describe Deterministic::Result::Match do
+  include Deterministic
+
   it "can match Success" do
     expect(
       Success(1).match do

--- a/spec/lib/deterministic/result/result_map.rb
+++ b/spec/lib/deterministic/result/result_map.rb
@@ -1,14 +1,17 @@
 require 'spec_helper'
 
-include Deterministic
 
 describe Deterministic::Result do
+  include Deterministic
+
   context ">> (map)" do
     specify { expect(Success(0).map { |n| Success(n + 1) }).to eq Success(1) }
     specify { expect(Failure(0).map { |n| Success(n + 1) }).to eq Failure(0) }
 
     it "Failure stops execution" do
       class ChainUnderTest
+        include Deterministic
+
         alias :m :method
 
         def call
@@ -72,6 +75,8 @@ describe Deterministic::Result do
 
   context "using self as the context for success" do
     class SelfContextUnderTest
+      include Deterministic
+
       def call
         @step = 0
         Success(self).

--- a/spec/lib/deterministic/result/success_spec.rb
+++ b/spec/lib/deterministic/result/success_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper'
 require_relative '../monad_axioms'
 require_relative 'result_shared'
 
-include Deterministic
 
 describe Deterministic::Result::Success do
+  include Deterministic
 
   it_behaves_like 'a Monad' do
     let(:monad) { described_class }


### PR DESCRIPTION
I noticed a bug when playing around with mixing Deterministic into a class. Then I looked at the tests, and noticed that mixing into a class wasn't being tested in an isolated context, due to Deterministic being included into the global context.

This PR scopes all includes into `describe` blocks, avoiding the global context. With this, the bug I discovered in #12 was properly exposed, so I fixed that too.
