### PR TITLE
Remove space in lambda expression revert support for ruby 1.9.3

### DIFF
--- a/lib/deterministic/result.rb
+++ b/lib/deterministic/result.rb
@@ -90,8 +90,8 @@ module Deterministic
     def +(other)
       raise Deterministic::Monad::NotMonadError, "Expected #{other.inspect} to be an Result" unless other.is_a? Result
       match {
-        success -> (_) { other.success? } { |s| Result::Success.new(s + other.value)}
-        failure -> (_) { other.failure? } { |f| Result::Failure.new(f + other.value)}
+        success ->(_) { other.success? } { |s| Result::Success.new(s + other.value)}
+        failure ->(_) { other.failure? } { |f| Result::Failure.new(f + other.value)}
         success { other } # implied other.failure?
         failure { self }   # implied other.success?
       }


### PR DESCRIPTION
Space between `->` and `(_)` causes Syntax error in ruby version 1.9.3. 
Remove this space resolve problem.

```
[1] pry(main)> RUBY_VERSION
=> "1.9.3"
[2] pry(main)> -> (_) { puts "hello" }
SyntaxError: unexpected tLAMBEG, expecting $end
-> (_) { puts "hello" }
        ^
[2] pry(main)> ->(_) { puts "hello" }
=> #<Proc:0x000000013952a0@(pry):2 (lambda)>
```
