### PR TITLE
Put back result try?

### DIFF
--- a/lib/deterministic/result.rb
+++ b/lib/deterministic/result.rb
@@ -76,6 +76,15 @@ module Deterministic
         Failure(_) { |f| f } # implied other.success?
       }
     end
+
+    def try(proc=nil, &block)
+      map(proc, &block)
+    rescue => err
+      Result::Failure.new(err)
+    end
+
+    alias :>= :try
+
   }
 end
 

--- a/spec/lib/deterministic/result/result_map_spec.rb
+++ b/spec/lib/deterministic/result/result_map_spec.rb
@@ -143,7 +143,6 @@ describe Deterministic::Result do
 
   context ">= (try)" do
     it "try (>=) catches errors and wraps them as Failure" do
-      pending "not implemented"
       def error(ctx)
         raise "error #{ctx}"
       end


### PR DESCRIPTION
I don't know if there was some reasoning to why this was removed, but it is still described in the ReadMe and it seems useful to me.