### PR TITLE
Fix any? handling of primitive data types

### DIFF
--- a/lib/deterministic/option.rb
+++ b/lib/deterministic/option.rb
@@ -11,7 +11,7 @@ module Deterministic
       end
 
       def any?(expr)
-        to_option(expr) { expr.nil? || not(expr.respond_to?(:empty?)) || expr.empty? }
+        to_option(expr) { expr.nil? || (expr.respond_to?(:empty?) && expr.empty?) }
       end
 
       def to_option(expr, &predicate)
@@ -48,6 +48,8 @@ module Deterministic
     def none?
       is_a? Option::None
     end
+
+    alias :empty? :none?
 
     def value_or(n)
       match {

--- a/spec/lib/deterministic/option_spec.rb
+++ b/spec/lib/deterministic/option_spec.rb
@@ -117,6 +117,7 @@ describe Deterministic::Option do
     expect(described_class.any?({})).to  be_none
     expect(described_class.any?([1])).to eq Some([1])
     expect(described_class.any?({foo: 1})).to eq Some({foo: 1})
+    expect(described_class.any?(1)).to eq Some(1)
   end
 
   it "try!" do


### PR DESCRIPTION
As primitive data types such as FixNum does not respond to empty? it returns `None` when it is passed to `any?` 
Also according to documentation the following should work while it doesn't
```
Option.any?(1)                         # => Some(1)
```