### PR TITLE
Adjust logic for variant matcher context & args

### DIFF
--- a/lib/deterministic/enum.rb
+++ b/lib/deterministic/enum.rb
@@ -23,6 +23,16 @@ module Deterministic
         def name
           self.class.name.split("::")[-1]
         end
+
+        # Returns array. Will fail on Nullary objects.
+        # TODO: define a Unary module so we can define this method differently on Unary vs Binary
+        def wrapped_values
+          if self.is_a?(Deterministic::EnumBuilder::DataType::Binary)
+            value.values
+          else
+            [value]
+          end
+        end
       end
 
       module Nullary
@@ -103,6 +113,8 @@ module_function
       class << self; private :new; end
 
       def self.match(obj, &block)
+        caller_ctx = block.binding.eval 'self'
+
         matcher = self::Matcher.new(obj)
         matcher.instance_eval(&block)
 
@@ -116,17 +128,19 @@ module_function
           obj, type, block, args, guard = match
 
           if args.count == 0
-            return instance_exec(obj, &block)
+            return caller_ctx.instance_eval(&block)
           else
-            raise Enum::MatchError, "Pattern (#{args.join(', ')}) must match (#{obj.args.join(', ')})" if args.count != obj.args.count
-            context = exec_context(obj, args)
+            if args.count != obj.args.count
+              raise Enum::MatchError, "Pattern (#{args.join(', ')}) must match (#{obj.args.join(', ')})"
+            end
+            guard_ctx = guard_context(obj, args)
 
             if guard
-              if context.instance_exec(obj, &guard)
-                return context.instance_exec(obj, &block)
+              if guard_ctx.instance_exec(obj, &guard)
+                return caller_ctx.instance_exec(* obj.wrapped_values, &block)
               end
             else
-              return context.instance_exec(obj, &block)
+              return caller_ctx.instance_exec(* obj.wrapped_values, &block)
             end
           end
         }
@@ -137,7 +151,7 @@ module_function
       def self.variants; constants - [:Matcher, :MatchError]; end
 
       private
-      def self.exec_context(obj, args)
+      def self.guard_context(obj, args)
         if obj.is_a?(Deterministic::EnumBuilder::DataType::Binary)
           Struct.new(*(args)).new(*(obj.value.values))
         else

--- a/lib/deterministic/match.rb
+++ b/lib/deterministic/match.rb
@@ -1,3 +1,4 @@
+# TODO: remove dead code
 module Deterministic
   module PatternMatching
 

--- a/lib/deterministic/option.rb
+++ b/lib/deterministic/option.rb
@@ -29,15 +29,15 @@ module Deterministic
 
     def fmap(&fn)
       match {
-        Some(s) { |m| m.class.new(fn.(s)) }
-        None()  { |n| n }
+        Some(s) { |s| self.class.new(fn.(s)) }
+        None()  {     self }
       }
     end
 
     def map(&fn)
       match {
-        Some(s) { |m| m.bind(&fn) }
-        None()  { |n| n }
+        Some(s) { |s| self.bind(&fn) }
+        None()  {     self }
       }
     end
 
@@ -53,8 +53,8 @@ module Deterministic
 
     def value_or(n)
       match {
-        Some(s) { s }
-        None()  { n }
+        Some(s) { |s| s }
+        None()  {     n }
       }
     end
 
@@ -65,9 +65,9 @@ module Deterministic
     def +(other)
       match {
         None() { other }
-        Some(_, where { !other.is_a?(Option)}) { raise TypeError, "Other must be an #{Option}"}
-        Some(s, where { other.some? }) { Option::Some.new(s + other.value) }
-        Some(_) { |s| s }
+        Some(_, where { !other.is_a?(Option)}) {|_| raise TypeError, "Other must be an #{Option}"}
+        Some(s, where { other.some? }) {|s| Option::Some.new(s + other.value) }
+        Some(_) {|_| self }
       }
     end
   }

--- a/lib/deterministic/option.rb
+++ b/lib/deterministic/option.rb
@@ -29,15 +29,15 @@ module Deterministic
 
     def fmap(&fn)
       match {
-        Some(s) { |s| self.class.new(fn.(s)) }
-        None()  {     self }
+        Some() {|s| self.class.new(fn.(s)) }
+        None() {    self }
       }
     end
 
     def map(&fn)
       match {
-        Some(s) { |s| self.bind(&fn) }
-        None()  {     self }
+        Some() {|s| self.bind(&fn) }
+        None() {    self }
       }
     end
 
@@ -53,8 +53,8 @@ module Deterministic
 
     def value_or(n)
       match {
-        Some(s) { |s| s }
-        None()  {     n }
+        Some() {|s| s }
+        None() {    n }
       }
     end
 
@@ -65,9 +65,9 @@ module Deterministic
     def +(other)
       match {
         None() { other }
-        Some(_, where { !other.is_a?(Option)}) {|_| raise TypeError, "Other must be an #{Option}"}
-        Some(s, where { other.some? }) {|s| Option::Some.new(s + other.value) }
-        Some(_) {|_| self }
+        Some(where { !other.is_a?(Option) }) {|_| raise TypeError, "Other must be an #{Option}"}
+        Some(where { other.some? }) {|s| Option::Some.new(s + other.value) }
+        Some() {|_| self }
       }
     end
   }

--- a/lib/deterministic/result.rb
+++ b/lib/deterministic/result.rb
@@ -19,8 +19,8 @@ module Deterministic
   Deterministic::impl(Result) {
     def map(proc=nil, &block)
       match {
-        Success(_) { |_| self.bind(proc || block) }
-        Failure(_) { |_| self }
+        Success() {|_| self.bind(proc || block) }
+        Failure() {|_| self }
       }
     end
 
@@ -29,8 +29,8 @@ module Deterministic
 
     def map_err(proc=nil, &block)
       match {
-        Success(_) { |_| self }
-        Failure(_) { |_| self.bind(proc|| block) }
+        Success() {|_| self }
+        Failure() {|_| self.bind(proc|| block) }
       }
     end
 
@@ -54,26 +54,26 @@ module Deterministic
     def or(other)
       raise Deterministic::Monad::NotMonadError, "Expected #{other.inspect} to be a Result" unless other.is_a? Result
       match {
-        Success(_) { |_| self }
-        Failure(_) { |_| other }
+        Success() {|_| self }
+        Failure() {|_| other }
       }
     end
 
     def and(other)
       raise Deterministic::Monad::NotMonadError, "Expected #{other.inspect} to be a Result" unless other.is_a? Result
       match {
-        Success(_) { |_| other }
-        Failure(_) { |_| self }
+        Success() {|_| other }
+        Failure() {|_| self }
       }
     end
 
     def +(other)
       raise Deterministic::Monad::NotMonadError, "Expected #{other.inspect} to be a Result" unless other.is_a? Result
       match {
-        Success(s, where { other.success? } ) { |s| Result::Success.new(s + other.value) }
-        Failure(f, where { other.failure? } ) { |f| Result::Failure.new(f + other.value) }
-        Success(_) { |_| other } # implied other.failure?
-        Failure(_) { |_| self } # implied other.success?
+        Success(where { other.success? } ) {|s| Result::Success.new(s + other.value) }
+        Failure(where { other.failure? } ) {|f| Result::Failure.new(f + other.value) }
+        Success() {|_| other } # implied other.failure?
+        Failure() {|_| self } # implied other.success?
       }
     end
 

--- a/lib/deterministic/result.rb
+++ b/lib/deterministic/result.rb
@@ -19,8 +19,8 @@ module Deterministic
   Deterministic::impl(Result) {
     def map(proc=nil, &block)
       match {
-        Success(_) { |s| s.bind(proc || block) }
-        Failure(_) { |f| f }
+        Success(_) { |_| self.bind(proc || block) }
+        Failure(_) { |_| self }
       }
     end
 
@@ -29,8 +29,8 @@ module Deterministic
 
     def map_err(proc=nil, &block)
       match {
-        Success(_) { |s| s }
-        Failure(_) { |f| f.bind(proc|| block) }
+        Success(_) { |_| self }
+        Failure(_) { |_| self.bind(proc|| block) }
       }
     end
 
@@ -54,26 +54,26 @@ module Deterministic
     def or(other)
       raise Deterministic::Monad::NotMonadError, "Expected #{other.inspect} to be a Result" unless other.is_a? Result
       match {
-        Success(_) { |s| s }
-        Failure(_) { other}
+        Success(_) { |_| self }
+        Failure(_) { |_| other }
       }
     end
 
     def and(other)
       raise Deterministic::Monad::NotMonadError, "Expected #{other.inspect} to be a Result" unless other.is_a? Result
       match {
-        Success(_) { other }
-        Failure(_) { |f| f }
+        Success(_) { |_| other }
+        Failure(_) { |_| self }
       }
     end
 
     def +(other)
       raise Deterministic::Monad::NotMonadError, "Expected #{other.inspect} to be a Result" unless other.is_a? Result
       match {
-        Success(s, where { other.success?} ) { Result::Success.new(s + other.value) }
-        Failure(f, where { other.failure?} ) { Result::Failure.new(f + other.value) }
-        Success(_) { other } # implied other.failure?
-        Failure(_) { |f| f } # implied other.success?
+        Success(s, where { other.success? } ) { |s| Result::Success.new(s + other.value) }
+        Failure(f, where { other.failure? } ) { |f| Result::Failure.new(f + other.value) }
+        Success(_) { |_| other } # implied other.failure?
+        Failure(_) { |_| self } # implied other.success?
       }
     end
 

--- a/spec/examples/amount_spec.rb
+++ b/spec/examples/amount_spec.rb
@@ -16,17 +16,17 @@ end
 Deterministic::impl(Amount) {
   def to_s
     match {
-      Due(a)  { "%0.2f" % [a] }
-      Paid(a) { "-%0.2f" % [a] }
-      Info(a) { "(%0.2f)" % [a] }
+      Due(a)  {|a| "%0.2f" % [a] }
+      Paid(a) {|a| "-%0.2f" % [a] }
+      Info(a) {|a| "(%0.2f)" % [a] }
     }
   end
 
   def to_f
     match {
-      Info(a) { 0 }
-      Due(a)  { a }
-      Paid(a) { -1 * a }
+      Info(a) {|a| 0 }
+      Due(a)  {|a| a }
+      Paid(a) {|a| -1 * a }
     }
   end
 

--- a/spec/examples/amount_spec.rb
+++ b/spec/examples/amount_spec.rb
@@ -16,17 +16,17 @@ end
 Deterministic::impl(Amount) {
   def to_s
     match {
-      Due(a)  {|a| "%0.2f" % [a] }
-      Paid(a) {|a| "-%0.2f" % [a] }
-      Info(a) {|a| "(%0.2f)" % [a] }
+      Due()  {|a| "%0.2f" % [a] }
+      Paid() {|a| "-%0.2f" % [a] }
+      Info() {|a| "(%0.2f)" % [a] }
     }
   end
 
   def to_f
     match {
-      Info(a) {|a| 0 }
-      Due(a)  {|a| a }
-      Paid(a) {|a| -1 * a }
+      Info() {|a| 0 }
+      Due()  {|a| a }
+      Paid() {|a| -1 * a }
     }
   end
 

--- a/spec/examples/config_spec.rb
+++ b/spec/examples/config_spec.rb
@@ -11,8 +11,8 @@ class ElasticSearchConfig
 
   def hosts
     Option.any?(proc_env["RESFINITY_LOG_CLIENT_ES_HOST"]).match {
-      Some(s) {|s| { hosts: s.split(/, */) } }
-      None() { default_hosts }
+      Some() {|s| { hosts: s.split(/, */) } }
+      None() { default_hosts }  # calls ElasticSearchConfig instance's method
     }
   end
 
@@ -31,7 +31,7 @@ private
 end
 
 describe ElasticSearchConfig do
-  pending("match exec context must have access to parents block binding context") {
+  # NOTE: the "empty" cases also verify that the variant matchers use the enclosing context as self
 
   let(:cfg) { ElasticSearchConfig.new(environment, env) }
   context "test" do
@@ -72,5 +72,4 @@ describe ElasticSearchConfig do
       specify { expect(cfg.hosts).to eq({ hosts: ["acc.resfinity.net:9200"] }) }
     end
   end
-}
 end

--- a/spec/examples/config_spec.rb
+++ b/spec/examples/config_spec.rb
@@ -11,7 +11,7 @@ class ElasticSearchConfig
 
   def hosts
     Option.any?(proc_env["RESFINITY_LOG_CLIENT_ES_HOST"]).match {
-      Some(s) { { hosts: s.split(/, */) } }
+      Some(s) {|s| { hosts: s.split(/, */) } }
       None() { default_hosts }
     }
   end

--- a/spec/examples/list.rb
+++ b/spec/examples/list.rb
@@ -28,46 +28,46 @@ Deterministic::impl(List) {
 
   def first
     match {
-      Cons(_, _) { |c| c }
-      Nil() { |n| n }
+      Cons(_, _) { |_, _| self }
+      Nil() {  self }
     }
   end
 
   def last
     match {
-      Cons(h, t, where { t.null? }) { |c| return c }
-      Cons(_, t) { t.last }
-      Nil() { |n| n }
+      Cons(h, t, where { t.null? }) { |h, t| return self }
+      Cons(_, t) { |_, t| t.last }
+      Nil() { self }
     }
   end
 
   def head
     match {
-      Cons(h, _) { h }
-      Nil() { |n| n }
+      Cons(h, _) { |h, _| h }
+      Nil() { self }
     }
   end
 
   def tail
     match {
-      Cons(_, t) { t }
-      Nil() { |n| raise EmptyListError }
+      Cons(_, t) { |_, t| t }
+      Nil() { raise EmptyListError }
     }
   end
 
   def init
     match {
-      Cons(h, t, where { |c| t.tail.null? } ) { |c| Cons.new(h, Nil.new) }
-      Cons(h, t) { |c| Cons.new(h, t.init) }
+      Cons(h, t, where {  t.tail.null? } ) { |h, t| Cons.new(h, Nil.new) }
+      Cons(h, t) { |h, t| Cons.new(h, t.init) }
       Nil() { raise EmptyListError }
     }
   end
 
   def filter(&pred)
     match {
-      Cons(h, t, where { pred.(h) }) { |c| Cons.new(h, t.filter(&pred)) }
-      Cons(_, t) { t.filter(&pred) }
-      Nil() { |n| n }
+      Cons(h, t, where { pred.(h) }) { |h, t| Cons.new(h, t.filter(&pred)) }
+      Cons(_, t) { |_, t| t.filter(&pred) }
+      Nil() { self }
     }
   end
 
@@ -76,21 +76,21 @@ Deterministic::impl(List) {
   def find(&pred)
     match {
       Nil() { Deterministic::Option::None.new }
-      Cons(h, t) { if pred.(h) then Deterministic::Option::Some.new(h) else t.find(&pred) end }
+      Cons(h, t) { |h, t| if pred.(h) then Deterministic::Option::Some.new(h) else t.find(&pred) end }
     }
   end
 
   def length
     match {
-      Cons(h, t) { 1 + t.length }
+      Cons(h, t) { |h, t| 1 + t.length }
       Nil() { 0 }
     }
   end
 
   def map(&fn)
     match {
-      Cons(h, t) { Cons.new(fn.(h), t.map(&fn)) }
-      Nil() { |n| n }
+      Cons(h, t) { |h, t| Cons.new(fn.(h), t.map(&fn)) }
+      Nil() { self }
     }
   end
 
@@ -102,14 +102,14 @@ Deterministic::impl(List) {
     match {
       Nil() { start }
       # foldl f z (x:xs) = foldl f (f z x) xs
-      Cons(h, t) { t.foldl(fn.(start, h), &fn) }
+      Cons(h, t) { |h, t| t.foldl(fn.(start, h), &fn) }
     }
   end
 
   def foldl1(&fn)
     match {
       Nil() { raise EmptyListError }
-      Cons(h, t) { t.foldl(h, &fn)}
+      Cons(h, t) { |h, t| t.foldl(h, &fn)}
     }
   end
 
@@ -117,31 +117,31 @@ Deterministic::impl(List) {
     match {
       Nil() { start }
       # foldr f z (x:xs) = f x (foldr f z xs)
-      Cons(h, t) { fn.(h, t.foldr(start, &fn)) }
+      Cons(h, t) { |h, t| fn.(h, t.foldr(start, &fn)) }
     }
   end
 
   def foldr1(&fn)
     match {
       Nil() { raise EmptyListError }
-      Cons(h, t, where { t.null? }) { h }
+      Cons(h, t, where { t.null? }) { |h, t| h }
       # foldr1 f (x:xs) =  f x (foldr1 f xs)
-      Cons(h, t) { fn.(h, t.foldr1(&fn)) }
+      Cons(h, t) { |h, t| fn.(h, t.foldr1(&fn)) }
     }
   end
 
   def take(n)
     match {
-      Cons(h, t, where { n > 0 }) { Cons.new(h, t.take(n - 1))}
-      Cons(_, _) { Nil.new }
+      Cons(h, t, where { n > 0 }) { |h, t| Cons.new(h, t.take(n - 1))}
+      Cons(_, _) { |_, _| Nil.new }
       Nil() { raise EmptyListError}
     }
   end
 
   def drop(n)
     match {
-      Cons(h, t, where { n > 0 }) { t.drop(n - 1) }
-      Cons(_, _) { |c| c }
+      Cons(h, t, where { n > 0 }) { |h, t| t.drop(n - 1) }
+      Cons(_, _) { |_, _| self }
       Nil() { raise EmptyListError}
     }
   end
@@ -153,31 +153,31 @@ Deterministic::impl(List) {
   def any?(&pred)
     match {
       Nil() { false }
-      Cons(h, t, where { t.null? }) { pred.(h) }
-      Cons(h, t) { pred.(h) || t.any?(&pred) }
+      Cons(h, t, where { t.null? }) { |h, t| pred.(h) }
+      Cons(h, t) { |h, t| pred.(h) || t.any?(&pred) }
     }
   end
 
   def all?(&pred)
     match {
       Nil() { false }
-      Cons(h, t, where { t.null? }) { pred.(h) }
-      Cons(h, t)                    { pred.(h) && t.all?(&pred) }
+      Cons(h, t, where { t.null? }) { |h, t| pred.(h) }
+      Cons(h, t)                    { |h, t| pred.(h) && t.all?(&pred) }
     }
   end
 
   def reverse
     match {
-      Nil() { |n| n }
-      Cons(_, t, where { t.null? }) { |c| c }
-      Cons(h, t) { |c| Cons.new(c.last.head, c.init.reverse) }
+      Nil() { self }
+      Cons(_, t, where { t.null? }) { |_, t| self }
+      Cons(h, t) { |h, t| Cons.new(self.last.head, self.init.reverse) }
     }
   end
 
   def to_s(joiner = ", ")
     match {
       Nil() { "Nil" }
-      Cons(head, tail) { head.to_s + joiner + tail.to_s }
+      Cons(head, tail) { |head, tail| head.to_s + joiner + tail.to_s }
     }
   end
 }

--- a/spec/examples/list.rb
+++ b/spec/examples/list.rb
@@ -28,45 +28,45 @@ Deterministic::impl(List) {
 
   def first
     match {
-      Cons(_, _) { |_, _| self }
+      Cons() {|_, _| self }
       Nil() {  self }
     }
   end
 
   def last
     match {
-      Cons(h, t, where { t.null? }) { |h, t| return self }
-      Cons(_, t) { |_, t| t.last }
+      Cons(where { t.null? }) {|h, t| return self }
+      Cons() {|_, t| t.last }
       Nil() { self }
     }
   end
 
   def head
     match {
-      Cons(h, _) { |h, _| h }
+      Cons() {|h, _| h }
       Nil() { self }
     }
   end
 
   def tail
     match {
-      Cons(_, t) { |_, t| t }
+      Cons() { |_, t| t }
       Nil() { raise EmptyListError }
     }
   end
 
   def init
     match {
-      Cons(h, t, where {  t.tail.null? } ) { |h, t| Cons.new(h, Nil.new) }
-      Cons(h, t) { |h, t| Cons.new(h, t.init) }
+      Cons(where { t.tail.null? } ) {|h, t| Cons.new(h, Nil.new) }
+      Cons() {|h, t| Cons.new(h, t.init) }
       Nil() { raise EmptyListError }
     }
   end
 
   def filter(&pred)
     match {
-      Cons(h, t, where { pred.(h) }) { |h, t| Cons.new(h, t.filter(&pred)) }
-      Cons(_, t) { |_, t| t.filter(&pred) }
+      Cons(where { pred.(h) }) {|h, t| Cons.new(h, t.filter(&pred)) }
+      Cons() {|_, t| t.filter(&pred) }
       Nil() { self }
     }
   end
@@ -76,20 +76,20 @@ Deterministic::impl(List) {
   def find(&pred)
     match {
       Nil() { Deterministic::Option::None.new }
-      Cons(h, t) { |h, t| if pred.(h) then Deterministic::Option::Some.new(h) else t.find(&pred) end }
+      Cons() {|h, t| pred.(h) ? Deterministic::Option::Some.new(h) : t.find(&pred) }
     }
   end
 
   def length
     match {
-      Cons(h, t) { |h, t| 1 + t.length }
+      Cons() {|h, t| 1 + t.length }
       Nil() { 0 }
     }
   end
 
   def map(&fn)
     match {
-      Cons(h, t) { |h, t| Cons.new(fn.(h), t.map(&fn)) }
+      Cons() {|h, t| Cons.new(fn.(h), t.map(&fn)) }
       Nil() { self }
     }
   end
@@ -102,14 +102,14 @@ Deterministic::impl(List) {
     match {
       Nil() { start }
       # foldl f z (x:xs) = foldl f (f z x) xs
-      Cons(h, t) { |h, t| t.foldl(fn.(start, h), &fn) }
+      Cons() {|h, t| t.foldl(fn.(start, h), &fn) }
     }
   end
 
   def foldl1(&fn)
     match {
       Nil() { raise EmptyListError }
-      Cons(h, t) { |h, t| t.foldl(h, &fn)}
+      Cons() {|h, t| t.foldl(h, &fn)}
     }
   end
 
@@ -117,32 +117,32 @@ Deterministic::impl(List) {
     match {
       Nil() { start }
       # foldr f z (x:xs) = f x (foldr f z xs)
-      Cons(h, t) { |h, t| fn.(h, t.foldr(start, &fn)) }
+      Cons() {|h, t| fn.(h, t.foldr(start, &fn)) }
     }
   end
 
   def foldr1(&fn)
     match {
       Nil() { raise EmptyListError }
-      Cons(h, t, where { t.null? }) { |h, t| h }
+      Cons(where { t.null? }) {|h, t| h }
       # foldr1 f (x:xs) =  f x (foldr1 f xs)
-      Cons(h, t) { |h, t| fn.(h, t.foldr1(&fn)) }
+      Cons() {|h, t| fn.(h, t.foldr1(&fn)) }
     }
   end
 
   def take(n)
     match {
-      Cons(h, t, where { n > 0 }) { |h, t| Cons.new(h, t.take(n - 1))}
-      Cons(_, _) { |_, _| Nil.new }
-      Nil() { raise EmptyListError}
+      Cons(where { n > 0 }) {|h, t| Cons.new(h, t.take(n - 1)) }
+      Cons() {|_, _| Nil.new }
+      Nil() { raise EmptyListError }
     }
   end
 
   def drop(n)
     match {
-      Cons(h, t, where { n > 0 }) { |h, t| t.drop(n - 1) }
-      Cons(_, _) { |_, _| self }
-      Nil() { raise EmptyListError}
+      Cons(where { n > 0 }) {|h, t| t.drop(n - 1) }
+      Cons() {|_, _| self }
+      Nil() { raise EmptyListError }
     }
   end
 
@@ -153,31 +153,31 @@ Deterministic::impl(List) {
   def any?(&pred)
     match {
       Nil() { false }
-      Cons(h, t, where { t.null? }) { |h, t| pred.(h) }
-      Cons(h, t) { |h, t| pred.(h) || t.any?(&pred) }
+      Cons(where { t.null? }) {|h, t| pred.(h) }
+      Cons() {|h, t| pred.(h) || t.any?(&pred) }
     }
   end
 
   def all?(&pred)
     match {
       Nil() { false }
-      Cons(h, t, where { t.null? }) { |h, t| pred.(h) }
-      Cons(h, t)                    { |h, t| pred.(h) && t.all?(&pred) }
+      Cons(where { t.null? }) {|h, t| pred.(h) }
+      Cons()                  {|h, t| pred.(h) && t.all?(&pred) }
     }
   end
 
   def reverse
     match {
       Nil() { self }
-      Cons(_, t, where { t.null? }) { |_, t| self }
-      Cons(h, t) { |h, t| Cons.new(self.last.head, self.init.reverse) }
+      Cons(where { t.null? }) {|_, t| self }
+      Cons() {|h, t| Cons.new(self.last.head, self.init.reverse) }
     }
   end
 
   def to_s(joiner = ", ")
     match {
       Nil() { "Nil" }
-      Cons(head, tail) { |head, tail| head.to_s + joiner + tail.to_s }
+      Cons() {|head, tail| head.to_s + joiner + tail.to_s }
     }
   end
 }

--- a/spec/examples/list_spec.rb
+++ b/spec/examples/list_spec.rb
@@ -13,9 +13,9 @@ describe List do
     it "catches ignores guards with non-matching clauses" do
       expect(
         list.match {
-          Nil()       { self }
-          Cons(h, t, where { h == 0 })  { h }
-          Cons(h, t)  { h }
+          Nil()       { list }
+          Cons(h, t, where { h == 0 })  {|h,t| h }
+          Cons(h, t)  {|h| h }
         }).to eq 1
     end
 
@@ -23,15 +23,15 @@ describe List do
       expect( # guard catched
         list.match {
           Nil() { raise "unreachable" }
-          Cons(h, t, where { h == 1 })  { h + 1 }
-          Cons(h, t)  { h }
+          Cons(h, t, where { h == 1 })  {|h,t| h + 1 }
+          Cons(h, t)  {|h| h }
         }).to eq 2
     end
 
     it "raises an error when no match was made" do
       expect {
         list.match {
-          Cons(_, _, where { true == false }) { 1 }
+          Cons(_, _, where { true == false }) {|_, _| 1 }
           Nil(where { true == false }) { 0 }
         }
       }.to raise_error(Deterministic::Enum::MatchError)
@@ -40,7 +40,7 @@ describe List do
     it "raises an error when the match is not exhaustive" do
       expect {
         list.match {
-          Cons(_, _) {}
+          Cons(_, _) {|_, _| }
         }
       }.to raise_error(Deterministic::Enum::MatchError)
     end

--- a/spec/examples/list_spec.rb
+++ b/spec/examples/list_spec.rb
@@ -14,8 +14,8 @@ describe List do
       expect(
         list.match {
           Nil()       { list }
-          Cons(h, t, where { h == 0 })  {|h,t| h }
-          Cons(h, t)  {|h| h }
+          Cons(where { h == 0 }) {|h,t| h }
+          Cons()  {|h, t| h }
         }).to eq 1
     end
 
@@ -23,15 +23,15 @@ describe List do
       expect( # guard catched
         list.match {
           Nil() { raise "unreachable" }
-          Cons(h, t, where { h == 1 })  {|h,t| h + 1 }
-          Cons(h, t)  {|h| h }
+          Cons(where { h == 1 }) {|h,t| h + 1 }
+          Cons() {|h| h }
         }).to eq 2
     end
 
     it "raises an error when no match was made" do
       expect {
         list.match {
-          Cons(_, _, where { true == false }) {|_, _| 1 }
+          Cons(where { true == false }) {|_, _| 1 }
           Nil(where { true == false }) { 0 }
         }
       }.to raise_error(Deterministic::Enum::MatchError)
@@ -40,7 +40,7 @@ describe List do
     it "raises an error when the match is not exhaustive" do
       expect {
         list.match {
-          Cons(_, _) {|_, _| }
+          Cons() {|_, _| }
         }
       }.to raise_error(Deterministic::Enum::MatchError)
     end

--- a/spec/examples/logger_spec.rb
+++ b/spec/examples/logger_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
+# TODO: dead code?
 class Logger
     alias :m :method
 

--- a/spec/examples/logger_spec.rb
+++ b/spec/examples/logger_spec.rb
@@ -15,6 +15,7 @@ class Logger
   private
     attr_reader :repository
 
+    # TODO: this is never called; the matcher syntax is old
     def validate(item)
       return Failure(["Item cannot be empty"]) if item.blank?
       return Failure(["Item must be a Hash"]) unless item.is_a?(Hash)

--- a/spec/lib/deterministic/option_spec.rb
+++ b/spec/lib/deterministic/option_spec.rb
@@ -75,8 +75,8 @@ describe Deterministic::Option do
   it "match" do
     expect(
       Some(0).match {
-        Some(s, where { s == 1 } ) { |s| 99 }
-        Some(s, where { s == 0 }) { |s| s + 1 }
+        Some(where { s == 1 }) {|s| 99 }
+        Some(where { s == 0 }) {|s| s + 1 }
         None() {}
       }
     ).to eq 1
@@ -84,14 +84,14 @@ describe Deterministic::Option do
     expect(
       Some(1).match {
         None() { 0 }
-        Some(s) {|s| 1 }
+        Some() {|s| 1 }
       }
     ).to eq 1
 
     expect(
       Some(1).match {
         None() { 0 }
-        Some(s, where { s.is_a? Fixnum }) {|s| 1 }
+        Some(where { s.is_a? Fixnum }) {|s| 1 }
       }
     ).to eq 1
 

--- a/spec/lib/deterministic/option_spec.rb
+++ b/spec/lib/deterministic/option_spec.rb
@@ -75,8 +75,8 @@ describe Deterministic::Option do
   it "match" do
     expect(
       Some(0).match {
-        Some(s, where { s == 1 } ) { |n| 99 }
-        Some(s, where { s == 0 }) { |n| s + 1 }
+        Some(s, where { s == 1 } ) { |s| 99 }
+        Some(s, where { s == 0 }) { |s| s + 1 }
         None() {}
       }
     ).to eq 1
@@ -84,14 +84,14 @@ describe Deterministic::Option do
     expect(
       Some(1).match {
         None() { 0 }
-        Some(s) { 1 }
+        Some(s) {|s| 1 }
       }
     ).to eq 1
 
     expect(
       Some(1).match {
         None() { 0 }
-        Some(s, where { s.is_a? Fixnum }) { 1 }
+        Some(s, where { s.is_a? Fixnum }) {|s| 1 }
       }
     ).to eq 1
 

--- a/spec/lib/enum_spec.rb
+++ b/spec/lib/enum_spec.rb
@@ -77,8 +77,8 @@ describe Deterministic::Enum  do
       res =
         MyEnym.match(b) {
           Nullary()  { 0 }
-          Unary(a) { [a, b] }
-          Binary(x, y) { [x, y]}
+          Unary(a) {|a| a }
+          Binary(x, y) {|x,y| [x, y] }
         }
 
       expect(res).to eq [1, 2]
@@ -86,8 +86,8 @@ describe Deterministic::Enum  do
       res =
         b.match {
           Nullary()  { 0 }
-          Unary(a) { [a, b] }
-          Binary(x, y) { [x, y]}
+          Unary(a) {|a| a }
+          Binary(x, y) {|x,y| [x, y] }
         }
 
       expect(res).to eq [1, 2]

--- a/spec/lib/enum_spec.rb
+++ b/spec/lib/enum_spec.rb
@@ -27,7 +27,7 @@ describe Deterministic::Enum  do
       expect(n).to be_a MyEnym
       expect(n).to be_a MyEnym::Nullary
       expect(n.name).to eq "Nullary"
-      expect { n.value }.to raise_error
+      expect { n.value }.to raise_error NoMethodError
       expect(n.inspect).to eq "Nullary"
       expect(n.to_s).to eq ""
       expect(n.fmap { }).to eq n
@@ -77,8 +77,8 @@ describe Deterministic::Enum  do
       res =
         MyEnym.match(b) {
           Nullary()  { 0 }
-          Unary(a) {|a| a }
-          Binary(x, y) {|x,y| [x, y] }
+          Unary() {|a| a }
+          Binary() {|x,y| [x, y] }
         }
 
       expect(res).to eq [1, 2]
@@ -86,8 +86,8 @@ describe Deterministic::Enum  do
       res =
         b.match {
           Nullary()  { 0 }
-          Unary(a) {|a| a }
-          Binary(x, y) {|x,y| [x, y] }
+          Unary() {|a| a }
+          Binary() {|x,y| [x, y] }
         }
 
       expect(res).to eq [1, 2]
@@ -98,10 +98,10 @@ describe Deterministic::Enum  do
       }.to raise_error(NameError)
 
       expect { b.match {
-        Nullary()
-        Unary()
-        Binary()
-      }
+                 Nullary()
+                 Unary()
+                 Binary()
+               }
       }.to raise_error ArgumentError, "No block given to `Nullary`"
     end
   end

--- a/spec/readme_spec.rb
+++ b/spec/readme_spec.rb
@@ -20,19 +20,18 @@ Threenum = Deterministic::enum {
 
 Deterministic::impl(Threenum) {
   def sum
-
     match {
-      Nullary()    { 0 }
-      Unary(u)     {|u| u }
-      Binary(a, b) {|a,b| a + b }
+      Nullary() {        0 }
+      Unary()   { |u|    u }
+      Binary()  { |a, b| a + b }
     }
   end
 
   def +(other)
     match {
-      Nullary()    { other.sum }
-      Unary(a)     {|a| self.sum + other.sum }
-      Binary(a, b) {|a,b| self.sum + other.sum }
+      Nullary() {        other.sum }
+      Unary()   { |a|    self.sum + other.sum }
+      Binary()  { |a, b| self.sum + other.sum }
     }
   end
 }

--- a/spec/readme_spec.rb
+++ b/spec/readme_spec.rb
@@ -23,16 +23,16 @@ Deterministic::impl(Threenum) {
 
     match {
       Nullary()    { 0 }
-      Unary(u)     { u }
-      Binary(a, b) { a + b }
+      Unary(u)     {|u| u }
+      Binary(a, b) {|a,b| a + b }
     }
   end
 
   def +(other)
     match {
       Nullary()    { other.sum }
-      Unary(a)     { |this| this.sum + other.sum }
-      Binary(a, b) { |this| this.sum + other.sum }
+      Unary(a)     {|a| self.sum + other.sum }
+      Binary(a, b) {|a,b| self.sum + other.sum }
     }
   end
 }


### PR DESCRIPTION
Fix for #28

API breaking changes (also in commit messages):
1. Block is passed the variant's values
2. Due to 1, block's first arg is no longer the variant instance
3. Variant matchers no longer accept arg names