### PR TITLE
Fix test code interfering with in_sequence usage

### DIFF
--- a/lib/deterministic/sequencer.rb
+++ b/lib/deterministic/sequencer.rb
@@ -81,25 +81,22 @@ module Deterministic
     # OperationWrapper proxies all method calls to the wrapped instance, but
     # first checks if the name of the called method matches a value stored
     # within @gotten_results and returns the value if it does.
-    class OperationWrapper
-      def initialize(instance)
-        @instance = instance
+    class OperationWrapper < SimpleDelegator
+      def initialize(*args)
+        super
         @gotten_results = {}
       end
 
-      # Disable rubocop rule which requires the method to fall back onto super,
-      # which is not what we want to do here, because we want the wrapped
-      # instance to have the last word.
-      def method_missing(name, *args, &block) # rubocop:disable Style/MethodMissing
+      def method_missing(name, *args, &block)
         if @gotten_results.key?(name)
           @gotten_results[name]
         else
-          @instance.send(name, *args, &block)
+          super
         end
       end
 
       def respond_to_missing?(name, include_private = false)
-        @gotten_results.key?(name) || @instance.send(:respond_to_missing?, name, include_private)
+        @gotten_results.key?(name) || super
       end
     end
   end

--- a/spec/lib/deterministic/sequencer_spec.rb
+++ b/spec/lib/deterministic/sequencer_spec.rb
@@ -112,7 +112,7 @@ describe Deterministic::Sequencer do
           get(:get_result) { getter }
           and_yield { arbitrary_success }
         end
-      end.to raise_error(NoMethodError)
+      end.to raise_error(NameError)
     end
 
     it 'its result is available in a subsequent #and_then' do
@@ -136,7 +136,7 @@ describe Deterministic::Sequencer do
           get(:get_result) { getter }
           and_yield { arbitrary_success }
         end
-      end.to raise_error(NoMethodError)
+      end.to raise_error(NameError)
     end
 
     it 'its result is available in a subsequent #observe' do
@@ -160,7 +160,7 @@ describe Deterministic::Sequencer do
           get(:get_result) { getter }
           and_yield { arbitrary_success }
         end
-      end.to raise_error(NoMethodError)
+      end.to raise_error(NameError)
     end
 
     it 'its result is available in #and_yield' do
@@ -319,6 +319,15 @@ describe Deterministic::Sequencer do
     end
   end
 
+
+  it 'does not allow calling methods outside of the wrapped instance' do
+    expect do
+      in_sequence do
+        and_yield { top_level_test_method }
+      end
+    end.to raise_error(NameError)
+  end
+
   context 'when including Deterministic::Prelude' do
     let(:test_class) { Class.new { include Deterministic::Prelude } }
 
@@ -411,4 +420,8 @@ describe Deterministic::Sequencer do
       in_sequence(&block)
     end
   end
+end
+
+def top_level_test_method
+  :empty
 end


### PR DESCRIPTION
For some reason I don't really understand, the simplistic OperationWrapper
implementation would allow calling top-level methods defined in the test code.
Not only would it allow calling those methods, but it also preferred those
methods to the ones defined in the wrapped instance, which means test code
could inadvertently interfere with the code under test.

Using Ruby's own SimpleDelegator avoids this issue.