### PR TITLE
Add let to in_sequence for simple assignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ try! { raise "hell" }                  # => Failure(#<RuntimeError: hell>)
 
 ### Result Chaining
 
-You can easily chain the execution of several operations. Here we got some nice function composition.  
+You can easily chain the execution of several operations. Here we got some nice function composition.
 The method must be a unary function, i.e. it always takes one parameter - the context, which is passed from call to call.
 
 The following aliases are defined

--- a/README.md
+++ b/README.md
@@ -227,6 +227,8 @@ class Foo
       get(:sanitized_input) { sanitize(input) }
       and_then              { validate(sanitized_input) }
       get(:user)            { get_user_from_db(sanitized_input) }
+      let(:name)            { user.fetch(:name) }
+      observe               { log('user name', name) }
       get(:request)         { build_request(sanitized_input, user) }
       observe               { log('sending request', request) }
       get(:response)        { send_request(request) }
@@ -245,7 +247,7 @@ class Foo
   end
 
   def get_user_from_db(sanitized_input)
-    Success(type: :admin, id: sanitized_input.fetch(:id))
+    Success(type: :admin, id: sanitized_input.fetch(:id), name: 'John')
   end
 
   def build_request(sanitized_input, user)
@@ -282,6 +284,10 @@ Here's what the operators used in this example mean:
   that identifier. If the `Result` is a `Failure`, then the entire chain will
   be short-circuited and the `Failure` will be returned as the result of the
   `in_sequence` call.
+* `let` - Execute the provided block and assign its result to the specified
+  identifier. The result can be anything - it is *not* expected to be
+  a `Result`. This is useful for simple assignments that don't need to be
+  wrapped in a `Result`. E.g. `let(:four) { 2 + 2 }`.
 * `and_then` - Execute the provided block and expect a `Result` as its return
   value. If the `Result` is a `Success`, then the chain continues, otherwise
   the chain is short-circuited and the `Failure` will be returned as the result

--- a/README.md
+++ b/README.md
@@ -275,6 +275,22 @@ directly, without having to call `#method` or having them return procs.
 The chain will still be short-circuited when e.g. `#validate` returns a
 `Failure`.
 
+Here's what the operators used in this example mean:
+* `get` - Execute the provided block and expect a `Result` as its return value.
+  If the `Result` is a `Success`, then the `Success` value is assigned to the
+  specified identifier. The value is then accessible in subsequent blocks by
+  that identifier. If the `Result` is a `Failure`, then the entire chain will
+  be short-circuited and the `Failure` will be returned as the result of the
+  `in_sequence` call.
+* `and_then` - Execute the provided block and expect a `Result` as its return
+  value. If the `Result` is a `Success`, then the chain continues, otherwise
+  the chain is short-circuited and the `Failure` will be returned as the result
+  of the `in_sequence` call.
+* `observe` - Execute the provided block whose return value will be ignored.
+  The chain continues regardless.
+* `and_yield` - Execute the provided block and expect a `Result` as its return
+  value. The `Result` will be returned as the result of the `in_sequence` call.
+
 ### Pattern matching
 Now that you have some result, you want to control flow by providing patterns.
 `#match` can match by


### PR DESCRIPTION
Its usage and usefulness is exemplified by the README example. It can be
thought of as equivalent to simple `=` assignments in Haskell's `do` block, for
example.