### PR TITLE
Improve in_sequence performance

### DIFF
--- a/lib/deterministic/result.rb
+++ b/lib/deterministic/result.rb
@@ -18,20 +18,14 @@ module Deterministic
 
   Deterministic::impl(Result) {
     def map(proc=nil, &block)
-      match {
-        Success() {|_| self.bind(proc || block) }
-        Failure() {|_| self }
-      }
+      success? ? bind(proc || block) : self
     end
 
     alias :>> :map
     alias :and_then :map
 
     def map_err(proc=nil, &block)
-      match {
-        Success() {|_| self }
-        Failure() {|_| self.bind(proc|| block) }
-      }
+      failure? ? bind(proc || block) : self
     end
 
     alias :or_else :map_err

--- a/spec/lib/deterministic/sequencer_spec.rb
+++ b/spec/lib/deterministic/sequencer_spec.rb
@@ -293,7 +293,7 @@ describe Deterministic::Sequencer do
           let(:a) { object.fetch(:a) }
           and_yield { arbitrary_success }
         end
-      end.to raise_error(NoMethodError)
+      end.to raise_error(NameError)
     end
 
     it 'its result is available in a subsequent #and_then' do
@@ -317,7 +317,7 @@ describe Deterministic::Sequencer do
           let(:a) { object.fetch(:a) }
           and_yield { arbitrary_success }
         end
-      end.to raise_error(NoMethodError)
+      end.to raise_error(NameError)
     end
 
     it 'its result is available in a subsequent #observe' do
@@ -341,7 +341,7 @@ describe Deterministic::Sequencer do
           let(:a) { object.fetch(:a) }
           and_yield { arbitrary_success }
         end
-      end.to raise_error(NoMethodError)
+      end.to raise_error(NameError)
     end
 
     it 'its result is available in #and_yield' do


### PR DESCRIPTION
I noticed that every time I added an `and_then`, `get`, etc statement in
in_sequence my app performance went down (quite a lot).

I started debugging and discovered that Deterministic match function is
very slow.

I benchmarked my code with this:
```
  puts Benchmark.measure {
    1_000.times do
      in_sequence do
        and_then { Success(nil) }
        and_then { Success(nil) }
        and_then { Success(nil) }
        and_then { Success(nil) }
        and_then { Success(nil) }
        and_then { Success(nil) }
        and_then { Success(nil) }
        and_then { Success(nil) }
        and_then { Success(nil) }
        and_then { Success(nil) }
        and_then { Success(nil) }
        and_then { Success(nil) }
        and_then { Success(nil) }
        and_then { Success(nil) }
        and_yield { Success(nil) }
      end
    end
  }
```

Before the changes: 1.923379   0.004321   1.927700 (  1.929412)
After the changes: 0.047661   0.000067   0.047728 (  0.047729)

That's over 97% performance improvement.

I also changed how in_sequence is evaluated. I was able to remove few
instance_eval calls and didn't use that recursive algorithm. This didn't
affect performance but it made exception stacktraces shorter and more
readable.