### PR TITLE
Add ruby2_keywords to sequencer

### DIFF
--- a/lib/deterministic/sequencer.rb
+++ b/lib/deterministic/sequencer.rb
@@ -111,7 +111,7 @@ module Deterministic
         @gotten_results = {}
       end
 
-      def method_missing(name, *args, &block)
+      ruby2_keywords def method_missing(name, *args, &block)
         if @gotten_results.key?(name)
           @gotten_results[name]
         else


### PR DESCRIPTION
Calling functions with keyword arguments from `sequencer.rb` produces keyword argument deprecation warnings in Ruby 2.7.

`ruby2_keywords` is added to `Sequencer::OperationWrapper::method_missing` function to fix the warning.

Sources:
https://eregon.me/blog/2021/02/13/correct-delegation-in-ruby-2-27-3.html 
https://eregon.me/blog/2019/11/10/the-delegation-challenge-of-ruby27.html