### PR TITLE
Add ruby2_keywords to sequencer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: Ruby workflows
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['2.7', '3.0', '3.1', '3.2']
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+      - name: Run tests
+        run: bundle exec rake

--- a/deterministic.gemspec
+++ b/deterministic.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{see above}
   spec.homepage      = "http://github.com/pzol/deterministic"
   spec.license       = "MIT"
-  spec.required_ruby_version = '>=1.9.3'
+  spec.required_ruby_version = '>=2.7'
 
   spec.files         = `git ls-files`.split($/)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/deterministic.gemspec
+++ b/deterministic.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler", '~> 2.0'
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", ">= 3"
   spec.add_development_dependency "guard"

--- a/lib/deterministic/null.rb
+++ b/lib/deterministic/null.rb
@@ -57,7 +57,7 @@ class Null
     false
   end
 
-  def respond_to?(m)
+  def respond_to?(m, *args)
     return true if @methods.empty? || @methods.include?(m)
     super
   end

--- a/lib/deterministic/sequencer.rb
+++ b/lib/deterministic/sequencer.rb
@@ -1,3 +1,5 @@
+require 'delegate'
+
 module Deterministic
   module Sequencer
     InvalidSequenceError = Class.new(StandardError)

--- a/lib/deterministic/sequencer.rb
+++ b/lib/deterministic/sequencer.rb
@@ -111,7 +111,7 @@ module Deterministic
         @gotten_results = {}
       end
 
-      def method_missing(name, *args, &block)
+      ruby2_keywords def method_missing(name, *args, &block)
         if @gotten_results.key?(name)
           @gotten_results[name]
         else

--- a/spec/examples/list_spec.rb
+++ b/spec/examples/list_spec.rb
@@ -163,7 +163,7 @@ describe List do
 
   context "all?" do
     subject(:list) { List[21, 15, 9] }
-    specify { expect(list.all? { |n| n.is_a?(Fixnum) }).to be_truthy }
+    specify { expect(list.all? { |n| n.is_a?(Integer) }).to be_truthy }
   end
 
   context "any?" do

--- a/spec/examples/logger_spec.rb
+++ b/spec/examples/logger_spec.rb
@@ -106,7 +106,6 @@ class Validator < Ensure
 end
 
 describe Ensure do
-  None = Deterministic::Option::None.new
   Some = Deterministic::Option::Some
 
   it "Ensure" do

--- a/spec/lib/deterministic/option_spec.rb
+++ b/spec/lib/deterministic/option_spec.rb
@@ -91,7 +91,7 @@ describe Deterministic::Option do
     expect(
       Some(1).match {
         None() { 0 }
-        Some(where { s.is_a? Fixnum }) {|s| 1 }
+        Some(where { s.is_a? Integer }) {|s| 1 }
       }
     ).to eq 1
 

--- a/spec/lib/deterministic/protocol_spec.rb
+++ b/spec/lib/deterministic/protocol_spec.rb
@@ -12,7 +12,7 @@ module Monoid
     }
   }
 
-  Int = Deterministic::instance(Monoid, M => Fixnum) {
+  Int = Deterministic::instance(Monoid, M => Integer) {
     def empty()
       0
     end
@@ -31,7 +31,7 @@ end
 
 describe Monoid do
   it "does something" do
-    expect(described_class.constants).to eq [:Protocol, :Int, :String]
+    expect(described_class.constants).to contain_exactly(:Protocol, :Int, :String)
     int = described_class::Int.new
     expect(int.empty).to eq 0
     expect(int.append(1, 2)).to eq 4

--- a/spec/lib/enum_spec.rb
+++ b/spec/lib/enum_spec.rb
@@ -69,8 +69,8 @@ describe Deterministic::Enum  do
     end
 
     it "generated enum" do
-      expect(MyEnym.variants).to eq [:Nullary, :Unary, :Binary]
-      expect(MyEnym.constants.inspect).to eq "[:Nullary, :Unary, :Binary, :Matcher]"
+      expect(MyEnym.variants).to contain_exactly(:Nullary, :Unary, :Binary)
+      expect(MyEnym.constants).to contain_exactly(:Nullary, :Unary, :Binary, :Matcher)
 
       b = MyEnym::Binary(a: 1, b: 2)
 


### PR DESCRIPTION
Calling functions with keyword arguments from `sequencer.rb` produces keyword argument deprecation warnings in Ruby 2.7.

`ruby2_keywords` is added to `Sequencer::OperationWrapper::method_missing` function to fix the warning.

Sources:
https://eregon.me/blog/2021/02/13/correct-delegation-in-ruby-2-27-3.html
https://eregon.me/blog/2019/11/10/the-delegation-challenge-of-ruby27.html

Current problems:
1. Tests does not run under Ruby 2.7+ (solved)
2. Should we add ruby2_keywords dependency somewhere (it worked without it when imported gem) (solved)
3. Should minimal version of Ruby bumped? (solved)